### PR TITLE
Package lsb-core removed

### DIFF
--- a/dep_install.sh
+++ b/dep_install.sh
@@ -69,7 +69,6 @@ instdep() {
 	parted
 	kpartx
 	csh
-	lsb-core
 	xtightvncviewer
 	diod
 	libncurses5-dev


### PR DESCRIPTION
Get info about user disto from /etc/os-release instead of /etc/lsb-release.